### PR TITLE
Code typo in overriding auto-detected isCategorical

### DIFF
--- a/DataScienceUtilities/DataReport-Utils/IDEAR.rmd
+++ b/DataScienceUtilities/DataReport-Utils/IDEAR.rmd
@@ -75,7 +75,7 @@ colNames = colnames(data)
 # override auto-detected isCategorical with the specified categorical variables in yaml
 if(!is.null(config$CategoricalColumns)){
   config$CategoricalColumns = make.names(config$CategoricalColumns, unique=TRUE)
-  for(v in config$CategoricalCoumns){
+  for(v in config$CategoricalColumns){
     isCategorical[v] = TRUE;
     isNumerical[v] = FALSE;
   }


### PR DESCRIPTION
When trying to create categorical feature out of a normally numerical feature, the feature would remain numerical. With this correction, the isCategorical override would work and the desired feature would become categorical.